### PR TITLE
add support for assets from a parent theme

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -84,7 +84,11 @@ class Plugin extends PluginBase
             return $customBaseUrl . $manifest[$path];
         }
 
-        return sprintf('/themes/%s/assets', $theme->getDirName()) . $manifest[$path];
+        if($theme->useParentAsset('assets' . $manifest[$path])) {
+            return sprintf('/themes/%s/assets', $theme->getParentTheme()->getDirName()) . $manifest[$path];
+        }
+
+        return  sprintf('/themes/%s/assets', $theme->getDirName()) . $manifest[$path];
     }
 
     /**


### PR DESCRIPTION
Hi there

this adds support for assets from parent themes. I did not do any exhaustive testing - e. g. themes with a chain of parents - but it works fine on 3 sites we have.